### PR TITLE
Parameterize secret settings with env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,14 @@ cd client-dashboard-files
    Create a `.env` file in the `backend` directory with the following variables:
    ```
    SECRET_KEY=your-secret-key
+   ALGORITHM=HS256
+   ACCESS_TOKEN_EXPIRE_MINUTES=120
    DATABASE_URL=sqlite:///./sql_app.db  # For development
    # For production, use:
    # DATABASE_URL=postgresql://user:password@localhost/dbname
    ```
+   If you plan to run the project with Docker Compose, copy `backend/.env.example`
+   to `backend/.env` so these variables are picked up automatically.
 
 4. **Run database migrations**:
    ```bash
@@ -121,9 +125,9 @@ cd client-dashboard-files
 ### Backend
 
 - `SECRET_KEY`: Secret key for JWT token generation
-- `DATABASE_URL`: Database connection URL
-- `ACCESS_TOKEN_EXPIRE_MINUTES`: JWT token expiration time (default: 1440 minutes / 24 hours)
 - `ALGORITHM`: JWT algorithm (default: HS256)
+- `ACCESS_TOKEN_EXPIRE_MINUTES`: JWT token expiration time (default: 120 minutes)
+- `DATABASE_URL`: Database connection URL
 
 ### Frontend
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
-SECRET_KEY=mysupersecretkey
+SECRET_KEY=your-secret-key
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=120
 DATABASE_URL=sqlite:///./app.db

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -7,20 +7,16 @@ from typing import Optional
 
 from .database import get_db
 from .models import User
-from .config import SECRET_KEY, ALGORITHM
+from .config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
-
-SECRET_KEY = "mysupersecretkey"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     to_encode = data.copy()
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,9 +9,11 @@ UPLOAD_DIR = BASE_DIR / "storage"
 UPLOAD_DIR.mkdir(exist_ok=True)
 
 # JWT Configuration
-SECRET_KEY = "mysupersecretkey"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+SECRET_KEY = os.getenv("SECRET_KEY", "change_me")
+ALGORITHM = os.getenv("ALGORITHM", "HS256")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(
+    os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+)
 
 # Database Configuration
 DATABASE_URL = "sqlite:///" + str(BASE_DIR / "app.db")

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -5,6 +5,7 @@ from ..models import User
 from ..database import get_db
 from ..utils import verify_password, create_access_token, get_password_hash
 from datetime import timedelta
+from ..config import ACCESS_TOKEN_EXPIRE_MINUTES
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -15,7 +16,7 @@ def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depend
         raise HTTPException(status_code=400, detail="Incorrect username or password")
     access_token = create_access_token(
         data={"sub": user.username, "role": user.role, "id": user.id, "client_id": user.client_id},
-        expires_delta=timedelta(minutes=120),
+        expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
     )
     return {"access_token": access_token, "token_type": "bearer"}
 

--- a/backend/app/routes/files.py
+++ b/backend/app/routes/files.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from ..database import get_db
 from ..models import FileMeta, User, LogEntry, Client
 from ..auth import get_current_user
-from ..config import UPLOAD_DIR
+from ..config import UPLOAD_DIR, SECRET_KEY, ALGORITHM
 import logging
 
 # Configure logging

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -6,10 +6,7 @@ from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 from .database import get_db
 from .models import User
-
-SECRET_KEY = "mysupersecretkey"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 120
+from .config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -24,7 +21,7 @@ def create_access_token(data: dict, expires_delta: timedelta = None):
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,8 @@ services:
     volumes:
       - ./backend:/code
       - ./backend/storage:/code/storage
-    environment:
-      - SECRET_KEY=mysupersecretkey
-      - ALGORITHM=HS256
-      - ACCESS_TOKEN_EXPIRE_MINUTES=120
-      - DATABASE_URL=sqlite:///./app.db
+    env_file:
+      - ./backend/.env
     ports:
       - "8000:8000"
     working_dir: /code


### PR DESCRIPTION
## Summary
- make `SECRET_KEY`, `ALGORITHM` and token expiry configurable via environment variables
- mount env file in Docker Compose
- document new variables and update example env file

## Testing
- `pytest -q` *(fails: ConnectionRefusedError and KeyError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68523853449083309e8007ae1b9914ca