### PR TITLE
Switch auth to shared utils

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import Session
 from datetime import datetime, timedelta
 from typing import Optional
 
+from .utils import verify_password as utils_verify_password
+
 from .database import get_db
 from .models import User
 from .config import SECRET_KEY, ALGORITHM
@@ -26,8 +28,8 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     return encoded_jwt
 
 def verify_password(plain_password: str, hashed_password: str):
-    # TODO: Implement proper password verification using bcrypt
-    return plain_password == hashed_password
+    """Wrap utils.verify_password for backward compatibility."""
+    return utils_verify_password(plain_password, hashed_password)
 
 def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
     credentials_exception = HTTPException(

--- a/backend/scripts/create_admin.py
+++ b/backend/scripts/create_admin.py
@@ -5,9 +5,9 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from sqlalchemy.orm import Session
-from passlib.context import CryptContext
 from app.database import SessionLocal, engine
 from app.models import Base, User
+from app.utils import get_password_hash
 
 # Create all tables
 Base.metadata.create_all(bind=engine)
@@ -15,13 +15,11 @@ Base.metadata.create_all(bind=engine)
 # Create session
 db = SessionLocal()
 
-# Create password hasher
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 # Create admin user
 admin_username = "admin"
 admin_password = "admin123"
-hashed_password = pwd_context.hash(admin_password)
+hashed_password = get_password_hash(admin_password)
 
 # Check if admin user already exists
 existing_admin = db.query(User).filter(User.username == admin_username).first()

--- a/backend/scripts/hash_existing_passwords.py
+++ b/backend/scripts/hash_existing_passwords.py
@@ -1,0 +1,29 @@
+import sys
+import os
+
+# Add backend directory to path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.database import SessionLocal
+from app.models import User
+from app.utils import get_password_hash
+
+
+def main():
+    db = SessionLocal()
+    try:
+        users = db.query(User).all()
+        updated = 0
+        for user in users:
+            if not user.password.startswith("$2"):
+                user.password = get_password_hash(user.password)
+                updated += 1
+        if updated:
+            db.commit()
+        print(f"Updated {updated} user password(s)")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/test_upload.py
+++ b/backend/scripts/test_upload.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.database import SessionLocal, engine
 from app.models import Base, User
-from passlib.context import CryptContext
+from app.utils import get_password_hash
 
 # Add app directory to Python path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -13,13 +13,12 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 client = TestClient(app)
 
 # Create admin user if it doesn't exist
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 def create_admin():
     db = SessionLocal()
     try:
         admin_username = "admin"
         admin_password = "admin123"
-        hashed_password = pwd_context.hash(admin_password)
+        hashed_password = get_password_hash(admin_password)
         
         existing_admin = db.query(User).filter(User.username == admin_username).first()
         if not existing_admin:


### PR DESCRIPTION
## Summary
- proxy auth.verify_password to utils.verify_password
- use utils password helpers in create_admin and test scripts
- add script to hash existing plaintext passwords

## Testing
- `python -m py_compile backend/app/auth.py backend/scripts/create_admin.py backend/scripts/test_upload.py backend/scripts/hash_existing_passwords.py`
- `pytest -q` *(fails: HTTPConnectionPool(host='127.0.0.1', port=8000) connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685238552ef48330b108abf0bb428947