### PR TITLE
Enable CSV uploads and log overwrites

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -36,5 +36,6 @@ class LogEntry(Base):
     id = Column(Integer, primary_key=True, index=True)
     user = Column(String)
     action = Column(String)
+    file_name = Column(String)
     file_id = Column(Integer, ForeignKey("files.id"))
     timestamp = Column(DateTime, default=datetime.datetime.utcnow)

--- a/backend/app/routes/analytics.py
+++ b/backend/app/routes/analytics.py
@@ -15,5 +15,6 @@ def get_logs(db: Session = Depends(get_db), user=Depends(get_current_user)):
         "user": l.user,
         "action": l.action,
         "file_id": l.file_id,
+        "file_name": getattr(l, "file_name", None),
         "timestamp": l.timestamp
     } for l in logs]

--- a/backend/app/routes/files.py
+++ b/backend/app/routes/files.py
@@ -376,9 +376,9 @@ async def upload_file(
         logger.info(f"Client ID: {client_id if user.role == 'admin' else user.client_id}")
         
         # Validate file type
-        if not file.filename.lower().endswith(('.xls', '.xlsx')):
+        if not file.filename.lower().endswith(('.xls', '.xlsx', '.csv')):
             logger.error(f"Error: Invalid file type for {file.filename}")
-            raise HTTPException(status_code=400, detail="File must be XLS or XLSX")
+            raise HTTPException(status_code=400, detail="File must be XLS, XLSX or CSV")
         
         # Validate file size (100MB limit)
         MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB in bytes
@@ -398,6 +398,20 @@ async def upload_file(
             if not client:
                 logger.error(f"Error: Client {client_id} not found")
                 raise HTTPException(status_code=404, detail="Client not found")
+
+        target_client_id = client_id if user.role == "admin" else user.client_id
+
+        # Delete existing file with same name for the same client/hospital
+        existing = db.query(FileMeta).filter(
+            FileMeta.filename == file.filename,
+            FileMeta.client_id == target_client_id
+        ).first()
+        if existing:
+            if existing.path and os.path.exists(existing.path):
+                os.remove(existing.path)
+            db.delete(existing)
+            db.add(LogEntry(user=str(user.id), action="overwrite", file_id=existing.id, file_name=existing.filename))
+            db.commit()
         
         # Create file metadata first to get the ID
         logger.info("=== Creating File Metadata ===")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -25,5 +25,6 @@ class LogEntry(BaseModel):
     id: Optional[int] = None
     user: str
     action: str
+    file_name: Optional[str] = None
     file_id: int
     timestamp: str


### PR DESCRIPTION
## Summary
- extend upload route to accept `.csv` files
- delete existing files with the same name and client before upload
- record overwrite events including filename in `LogEntry`
- expose `file_name` field via analytics

## Testing
- `pytest -q` *(fails: `pyenv: version 'client-dashboard-env' is not installed`)*

------
https://chatgpt.com/codex/tasks/task_e_685238599c148330b060f0f001f21c76