### PR TITLE
Add affordplan and manufacturer features

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .database import Base, engine
-from .routes import auth, files, analytics, admin
+from .routes import auth, files, analytics, admin, affordplan, manufacturer
 
 Base.metadata.create_all(bind=engine)
 
@@ -26,3 +26,5 @@ app.include_router(auth.router)
 app.include_router(files.router)
 app.include_router(analytics.router)
 app.include_router(admin.router)
+app.include_router(affordplan.router)
+app.include_router(manufacturer.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -8,9 +8,11 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True, index=True)
     password = Column(String)
-    role = Column(String)  # admin, client, employee
+    role = Column(String)  # admin, client, employee, affordplan, manufacturer
     client_id = Column(Integer, ForeignKey("clients.id"), nullable=True)
+    manufacturer_id = Column(Integer, ForeignKey("manufacturers.id"), nullable=True)
     client = relationship("Client", back_populates="users")
+    manufacturer = relationship("Manufacturer", back_populates="users", uselist=False)
 
 class Client(Base):
     __tablename__ = "clients"
@@ -38,3 +40,23 @@ class LogEntry(Base):
     action = Column(String)
     file_id = Column(Integer, ForeignKey("files.id"))
     timestamp = Column(DateTime, default=datetime.datetime.utcnow)
+
+
+class Manufacturer(Base):
+    __tablename__ = "manufacturers"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True)
+    processed_files = relationship("ProcessedFile", back_populates="manufacturer")
+    users = relationship("User", back_populates="manufacturer")
+
+
+class ProcessedFile(Base):
+    __tablename__ = "processed_files"
+    id = Column(Integer, primary_key=True, index=True)
+    hospital_file_id = Column(Integer, ForeignKey("files.id"))
+    manufacturer_id = Column(Integer, ForeignKey("manufacturers.id"))
+    filename = Column(String)
+    path = Column(String)
+    uploaded_by = Column(Integer, ForeignKey("users.id"))
+    quote_path = Column(String, nullable=True)
+    manufacturer = relationship("Manufacturer", back_populates="processed_files")

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -2,5 +2,14 @@ from .auth import router as auth_router
 from .files import router as files_router
 from .analytics import router as analytics_router
 from .admin import router as admin_router
+from .affordplan import router as affordplan_router
+from .manufacturer import router as manufacturer_router
 
-__all__ = ['auth_router', 'files_router', 'analytics_router', 'admin_router']
+__all__ = [
+    'auth_router',
+    'files_router',
+    'analytics_router',
+    'admin_router',
+    'affordplan_router',
+    'manufacturer_router'
+]

--- a/backend/app/routes/affordplan.py
+++ b/backend/app/routes/affordplan.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
+from sqlalchemy.orm import Session
+from fastapi.responses import FileResponse
+from ..database import get_db
+from ..models import FileMeta, ProcessedFile, Manufacturer, User
+from ..utils import get_current_user
+from ..config import UPLOAD_DIR
+import os
+import shutil
+
+router = APIRouter(prefix="/affordplan", tags=["affordplan"])
+
+@router.get("/hospital-uploads")
+def list_hospital_uploads(db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    if user.role != "affordplan":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return db.query(FileMeta).all()
+
+@router.get("/download/{file_id}")
+def download_hospital_file(file_id: int, db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    if user.role != "affordplan":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    file_meta = db.query(FileMeta).filter(FileMeta.id == file_id).first()
+    if not file_meta:
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(file_meta.path, filename=file_meta.filename)
+
+@router.post("/processed")
+async def upload_processed_file(
+    hospital_file_id: int = Form(...),
+    manufacturer_id: int = Form(...),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user)
+):
+    if user.role != "affordplan":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    manufacturer = db.query(Manufacturer).filter(Manufacturer.id == manufacturer_id).first()
+    if not manufacturer:
+        raise HTTPException(status_code=404, detail="Manufacturer not found")
+    if not db.query(FileMeta).filter(FileMeta.id == hospital_file_id).first():
+        raise HTTPException(status_code=404, detail="Hospital file not found")
+    processed = ProcessedFile(
+        hospital_file_id=hospital_file_id,
+        manufacturer_id=manufacturer_id,
+        filename=file.filename,
+        uploaded_by=user.id
+    )
+    db.add(processed)
+    db.commit()
+    db.refresh(processed)
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    path = os.path.join(UPLOAD_DIR, f"proc_{processed.id}_{file.filename}")
+    with open(path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+    processed.path = path
+    db.commit()
+    return {"id": processed.id}

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -22,18 +22,22 @@ def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depend
 # For demo only: seed users on first run
 @router.on_event("startup")
 def seed_demo_users():
-    from ..models import Client, User
+    from ..models import Client, User, Manufacturer
     from ..database import SessionLocal
     db = SessionLocal()
     if db.query(Client).count() == 0:
         c1 = Client(name="AcmeCorp")
-        db.add(c1)
+        m1 = Manufacturer(name="WidgetCo")
+        db.add_all([c1, m1])
         db.commit()
         db.refresh(c1)
+        db.refresh(m1)
         users = [
             User(username="admin", password=get_password_hash("admin123"), role="admin"),
             User(username="client1", password=get_password_hash("client123"), role="client", client_id=c1.id),
             User(username="employee1", password=get_password_hash("emp123"), role="employee", client_id=c1.id),
+            User(username="affordplan1", password=get_password_hash("afford123"), role="affordplan"),
+            User(username="manu1", password=get_password_hash("manu123"), role="manufacturer", manufacturer_id=m1.id),
         ]
         db.add_all(users)
         db.commit()

--- a/backend/app/routes/manufacturer.py
+++ b/backend/app/routes/manufacturer.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
+from sqlalchemy.orm import Session
+from fastapi.responses import FileResponse
+from ..database import get_db
+from ..models import ProcessedFile, User
+from ..utils import get_current_user
+from ..config import UPLOAD_DIR
+import os
+import shutil
+
+router = APIRouter(prefix="/manufacturer", tags=["manufacturer"])
+
+@router.get("/consumption")
+def list_consumption_files(db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    if user.role != "manufacturer":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return db.query(ProcessedFile).filter(ProcessedFile.manufacturer_id == user.manufacturer_id).all()
+
+@router.get("/download/{processed_id}")
+def download_consumption(processed_id: int, db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    if user.role != "manufacturer":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    processed = db.query(ProcessedFile).filter(ProcessedFile.id == processed_id, ProcessedFile.manufacturer_id == user.manufacturer_id).first()
+    if not processed:
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(processed.path, filename=processed.filename)
+
+@router.post("/quote")
+async def upload_quote(
+    processed_file_id: int = Form(...),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user)
+):
+    if user.role != "manufacturer":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    processed = db.query(ProcessedFile).filter(ProcessedFile.id == processed_file_id, ProcessedFile.manufacturer_id == user.manufacturer_id).first()
+    if not processed:
+        raise HTTPException(status_code=404, detail="Processed file not found")
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    quote_path = os.path.join(UPLOAD_DIR, f"quote_{processed_file_id}_{file.filename}")
+    with open(quote_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+    processed.quote_path = quote_path
+    db.commit()
+    return {"message": "Quote uploaded"}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -6,6 +6,7 @@ class User(BaseModel):
     username: str
     role: str
     client_id: Optional[int] = None
+    manufacturer_id: Optional[int] = None
 
 class Client(BaseModel):
     id: Optional[int] = None
@@ -27,3 +28,18 @@ class LogEntry(BaseModel):
     action: str
     file_id: int
     timestamp: str
+
+
+class Manufacturer(BaseModel):
+    id: Optional[int] = None
+    name: str
+
+
+class ProcessedFile(BaseModel):
+    id: Optional[int] = None
+    hospital_file_id: int
+    manufacturer_id: int
+    filename: str
+    path: str
+    uploaded_by: int
+    quote_path: Optional[str] = None

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,8 +3,11 @@ import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Upload from "./pages/Upload";
+import HospitalUpload from "./pages/HospitalUpload";
 import Analytics from "./pages/Analytics";
 import AdminDashboard from "./pages/AdminDashboard";
+import AffordplanDashboard from "./pages/AffordplanDashboard";
+import ManufacturerDashboard from "./pages/ManufacturerDashboard";
 import { format } from "date-fns";
 
 function App() {
@@ -66,7 +69,7 @@ function App() {
                   )}
                   {role === "client" && (
                     <Link
-                      to="/upload"
+                      to="/hospital-upload"
                       className="inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium text-white hover:border-primary-500 hover:text-white"
                     >
                       Upload
@@ -78,6 +81,22 @@ function App() {
                       className="inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium text-white hover:border-primary-500 hover:text-white"
                     >
                       Upload
+                    </Link>
+                  )}
+                  {role === "affordplan" && (
+                    <Link
+                      to="/affordplan"
+                      className="inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium text-white hover:border-primary-500 hover:text-white"
+                    >
+                      Affordplan
+                    </Link>
+                  )}
+                  {role === "manufacturer" && (
+                    <Link
+                      to="/manufacturer"
+                      className="inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium text-white hover:border-primary-500 hover:text-white"
+                    >
+                      Manufacturer
                     </Link>
                   )}
                 </div>
@@ -98,6 +117,9 @@ function App() {
           <Routes>
             <Route path="/dashboard" element={<Dashboard token={token} role={role} />} />
             <Route path="/upload" element={<Upload token={token} role={role} />} />
+            <Route path="/hospital-upload" element={<HospitalUpload token={token} role={role} />} />
+            <Route path="/affordplan" element={<AffordplanDashboard />} />
+            <Route path="/manufacturer" element={<ManufacturerDashboard />} />
             <Route path="/analytics" element={<Analytics token={token} role={role} />} />
             <Route path="/admin" element={<AdminDashboard token={token} role={role} />} />
             <Route path="/" element={<Dashboard token={token} role={role} />} />

--- a/frontend/src/pages/AffordplanDashboard.jsx
+++ b/frontend/src/pages/AffordplanDashboard.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import axios from '../api';
+import FileUpload from '../components/FileUpload';
+
+export default function AffordplanDashboard() {
+  const [files, setFiles] = useState([]);
+  const [procFile, setProcFile] = useState(null);
+  const [hospitalFileId, setHospitalFileId] = useState('');
+  const [manufacturerId, setManufacturerId] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    axios.get('/affordplan/hospital-uploads')
+      .then(res => setFiles(res.data))
+      .catch(() => setError('Failed to fetch uploads'));
+  }, []);
+
+  const handleProcessedUpload = async () => {
+    if (!procFile || !hospitalFileId || !manufacturerId) {
+      setError('All fields required');
+      return;
+    }
+    const formData = new FormData();
+    formData.append('file', procFile);
+    formData.append('hospital_file_id', hospitalFileId);
+    formData.append('manufacturer_id', manufacturerId);
+    try {
+      await axios.post('/affordplan/processed', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      });
+      setError('');
+      alert('Processed file uploaded');
+    } catch (e) {
+      setError('Upload failed');
+    }
+  };
+
+  const download = (id) => {
+    window.open(`/affordplan/download/${id}?token=${localStorage.getItem('token')}`);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Affordplan Dashboard</h1>
+      {error && <div className="text-red-600 mb-2">{error}</div>}
+      <table className="min-w-full divide-y divide-gray-200 mb-4">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Filename</th>
+            <th className="px-6 py-3"></th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {files.map(f => (
+            <tr key={f.id}>
+              <td className="px-6 py-4 whitespace-nowrap">{f.id}</td>
+              <td className="px-6 py-4 whitespace-nowrap">{f.filename}</td>
+              <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <button onClick={() => download(f.id)} className="text-indigo-600 hover:text-indigo-900">Download</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="bg-white p-4 rounded shadow">
+        <h2 className="text-lg font-semibold mb-2">Upload Processed File</h2>
+        <div className="mb-2">
+          <label className="block text-sm">Hospital File ID</label>
+          <input value={hospitalFileId} onChange={e => setHospitalFileId(e.target.value)} className="border rounded w-full" />
+        </div>
+        <div className="mb-2">
+          <label className="block text-sm">Manufacturer ID</label>
+          <input value={manufacturerId} onChange={e => setManufacturerId(e.target.value)} className="border rounded w-full" />
+        </div>
+        <FileUpload onFileSelect={setProcFile} uploading={false} error={''} />
+        <button onClick={handleProcessedUpload} className="mt-2 px-4 py-2 bg-blue-600 text-white rounded">Upload</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/HospitalUpload.jsx
+++ b/frontend/src/pages/HospitalUpload.jsx
@@ -1,0 +1,256 @@
+import React, { useState } from "react";
+import axios from "../api";
+import { format } from "date-fns";
+import { CalendarIcon } from "@heroicons/react/24/outline";
+import FileUpload from "../components/FileUpload";
+import DateRangePicker from "../components/DateRangePicker";
+import FileList from "../components/FileList";
+
+export default function HospitalUpload({ token, role: userRole }) {
+  const [file, setFile] = useState(null);
+  const [uploading, setUploading] = useState(false);
+  const [loadingClients, setLoadingClients] = useState(false);
+  const [error, setError] = useState("");
+  const [uploadHistory, setUploadHistory] = useState([]);
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
+  const [selectedClient, setSelectedClient] = useState("");
+  const [clients, setClients] = useState([]);
+
+  // Fetch history and clients when token or role changes
+  React.useEffect(() => {
+    console.log('useEffect - token:', token, 'role:', userRole);
+    if (token) {
+      console.log('Token exists, fetching history and clients...');
+      fetchUploadHistory();
+      if (userRole === 'admin') {
+        console.log('User is admin, fetching clients...');
+        fetchClients();
+      } else {
+        console.log('User is not admin, skipping client fetch');
+      }
+    } else {
+      console.log('No token available');
+    }
+  }, [token, userRole]);
+
+  const fetchClients = async () => {
+    console.log('fetchClients called, role:', userRole);
+    if (userRole !== 'admin') {
+      console.log('Not an admin, skipping client fetch');
+      return;
+    }
+    
+    try {
+      console.log('Fetching clients...');
+      setLoadingClients(true);
+      setError('');
+      const response = await axios.get('/admin/clients', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      console.log('Clients fetched:', response.data);
+      setClients(response.data);
+      
+      // Auto-select the first client if available
+      if (response.data.length > 0) {
+        console.log('Setting first client:', response.data[0]);
+        setSelectedClient(response.data[0].id.toString());
+      } else {
+        console.log('No clients available');
+      }
+    } catch (error) {
+      console.error('Error fetching clients:', error);
+      if (error.response) {
+        console.error('Error response:', error.response.data);
+      }
+      setError('Failed to fetch client list');
+    } finally {
+      setLoadingClients(false);
+    }
+  };
+
+  const fetchUploadHistory = async () => {
+    try {
+      const response = await axios.get('/files/history');
+      setUploadHistory(response.data);
+    } catch (error) {
+      console.error('Error fetching upload history:', error);
+      setError(error.response?.data?.detail || 'Failed to fetch upload history');
+    }
+  };
+
+  const validateDateRange = () => {
+    if (!startDate || !endDate) {
+      setError("Please select both start and end dates");
+      return false;
+    }
+    if (startDate > endDate) {
+      setError("Start date must be before end date");
+      return false;
+    }
+    setError("");
+    return true;
+  };
+
+  const validateFile = (file) => {
+    const maxSize = 100 * 1024 * 1024; // 100MB in bytes
+    const allowedTypes = ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                         'application/vnd.ms-excel'];
+    
+    if (!allowedTypes.includes(file.type)) {
+      setError("Please select an XLS or XLSX file");
+      return false;
+    }
+    
+    if (file.size > maxSize) {
+      setError("File size exceeds 100MB limit");
+      return false;
+    }
+    
+    setError("");
+    return true;
+  };
+
+  const handleUpload = async () => {
+    if (!file) {
+      setError("Please select a file");
+      return;
+    }
+
+    if (userRole === 'admin' && !selectedClient) {
+      setError("Please select a client for this upload");
+      return;
+    }
+
+    if (!validateDateRange()) return;
+    if (!validateFile(file)) return;
+
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('start_date', format(startDate, 'yyyy-MM-dd'));
+    formData.append('end_date', format(endDate, 'yyyy-MM-dd'));
+    if (userRole === 'admin') {
+      formData.append('client_id', selectedClient);
+    }
+
+    try {
+      setUploading(true);
+      setError("");
+      
+      const response = await axios.post('/files/upload', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data'
+        }
+      });
+
+      // Update upload history
+      fetchUploadHistory();
+    } catch (error) {
+      console.error('Upload error:', error);
+      setError(error.response?.data?.detail || 'Failed to upload file');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">Upload File</h1>
+        </div>
+        <div className="bg-white py-8 px-6 shadow rounded-lg sm:px-10">
+          <div className="space-y-6">
+            <h2 className="text-2xl font-semibold text-center text-gray-900">Upload Excel File</h2>
+            
+            {error && (
+              <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+                <span className="block sm:inline">{error}</span>
+              </div>
+            )}
+            
+            {userRole === 'admin' && (
+              <div className="mt-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Select Client
+                  <span className="text-red-500 ml-1">*</span>
+                </label>
+                {loadingClients ? (
+                  <div className="mt-1 block w-full pl-3 pr-10 py-2 text-base border border-gray-300 rounded-md bg-gray-100">
+                    Loading clients...
+                    <div className="text-xs text-gray-500 mt-1">Debug: {`loadingClients=${loadingClients}, clients.length=${clients.length}`}</div>
+                  </div>
+                ) : (
+                  <select
+                    value={selectedClient}
+                    onChange={(e) => setSelectedClient(e.target.value)}
+                    className="mt-1 block w-full pl-3 pr-10 py-2 text-base border border-gray-300 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm rounded-md"
+                    disabled={loadingClients || clients.length === 0}
+                  >
+                    {clients.length === 0 ? (
+                      <option value="">No clients available</option>
+                    ) : (
+                      <>
+                        <option value="">Select a client</option>
+                        {clients.map((client) => (
+                          <option key={client.id} value={client.id}>
+                            {client.name}
+                          </option>
+                        ))}
+                      </>
+                    )}
+                  </select>
+                )}
+                {clients.length === 0 && !loadingClients && (
+                  <p className="mt-1 text-sm text-red-600">No clients found. Please add clients first.</p>
+                )}
+              </div>
+            )}
+            
+            <div className="flex justify-center">
+              <FileUpload
+                onFileSelect={setFile}
+                uploading={uploading}
+                error={error}
+              />
+            </div>
+            
+            <div className="mt-6">
+              <DateRangePicker
+                startDate={startDate}
+                endDate={endDate}
+                onStartDateChange={setStartDate}
+                onEndDateChange={setEndDate}
+              />
+            </div>
+            
+            <div className="mt-6">
+              <button
+                onClick={handleUpload}
+                disabled={uploading || !file || !startDate || !endDate || (userRole === 'admin' && (!selectedClient || clients.length === 0))}
+                className="relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {uploading ? (
+                  <>
+                    <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    Uploading...
+                  </>
+                ) : (
+                  'Upload File'
+                )}
+              </button>
+            </div>
+          </div>
+          
+          <div className="mt-12">
+            <h2 className="text-xl font-semibold mb-4">Upload History</h2>
+            <FileList files={uploadHistory} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -25,6 +25,8 @@ export default function Login({ setToken, setRole }) {
       // Decode role from username for demo (in production, decode JWT)
       if (username === "admin") localStorage.setItem("role", "admin");
       else if (username === "employee1") localStorage.setItem("role", "employee");
+      else if (username === "affordplan1") localStorage.setItem("role", "affordplan");
+      else if (username === "manu1") localStorage.setItem("role", "manufacturer");
       else localStorage.setItem("role", "client");
       
       setRole(localStorage.getItem("role"));

--- a/frontend/src/pages/ManufacturerDashboard.jsx
+++ b/frontend/src/pages/ManufacturerDashboard.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import axios from '../api';
+import FileUpload from '../components/FileUpload';
+
+export default function ManufacturerDashboard() {
+  const [files, setFiles] = useState([]);
+  const [quoteFile, setQuoteFile] = useState(null);
+  const [selectedId, setSelectedId] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    axios.get('/manufacturer/consumption')
+      .then(res => setFiles(res.data))
+      .catch(() => setError('Failed to fetch files'));
+  }, []);
+
+  const uploadQuote = async () => {
+    if (!quoteFile || !selectedId) {
+      setError('Select file and processed ID');
+      return;
+    }
+    const formData = new FormData();
+    formData.append('file', quoteFile);
+    formData.append('processed_file_id', selectedId);
+    try {
+      await axios.post('/manufacturer/quote', formData, { headers: { 'Content-Type': 'multipart/form-data' }});
+      setError('');
+      alert('Quote uploaded');
+    } catch {
+      setError('Upload failed');
+    }
+  };
+
+  const download = (id) => {
+    window.open(`/manufacturer/download/${id}?token=${localStorage.getItem('token')}`);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Manufacturer Dashboard</h1>
+      {error && <div className="text-red-600 mb-2">{error}</div>}
+      <table className="min-w-full divide-y divide-gray-200 mb-4">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Filename</th>
+            <th className="px-6 py-3"></th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {files.map(f => (
+            <tr key={f.id}>
+              <td className="px-6 py-4 whitespace-nowrap">{f.id}</td>
+              <td className="px-6 py-4 whitespace-nowrap">{f.filename}</td>
+              <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <button onClick={() => download(f.id)} className="text-indigo-600 hover:text-indigo-900">Download</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="bg-white p-4 rounded shadow">
+        <h2 className="text-lg font-semibold mb-2">Upload Quote</h2>
+        <div className="mb-2">
+          <label className="block text-sm">Processed File ID</label>
+          <input value={selectedId} onChange={e => setSelectedId(e.target.value)} className="border rounded w-full" />
+        </div>
+        <FileUpload onFileSelect={setQuoteFile} uploading={false} error={''} />
+        <button onClick={uploadQuote} className="mt-2 px-4 py-2 bg-blue-600 text-white rounded">Upload</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add affordplan and manufacturer roles/models
- seed initial users and manufacturers
- create API routers for affordplan and manufacturer workflows
- update main router config
- extend frontend navigation
- add dashboards for affordplan and manufacturer
- add hospital upload page

## Testing
- `pytest -q` *(fails: pyenv pytest not found)*
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6852385c58888330a1beae14a0db3219