### PR TITLE
Extend roles and affordplan route

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A comprehensive file management dashboard that allows clients to upload files wi
 - **Role-Based Access Control**:
   - **Admin**: Full access to all features including user management
   - **Client**: File upload and view access to their own files
+  - **Manufacturer/Hospital**: Limited client-style access for their entity
+  - **Affordplan**: Can create manufacturer and hospital accounts
 - **File Management**:
   - Upload files with date range metadata
   - View and download files

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -8,7 +8,8 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True, index=True)
     password = Column(String)
-    role = Column(String)  # admin, client, employee
+    # Possible roles: admin, client, employee, manufacturer, hospital, affordplan
+    role = Column(String)
     client_id = Column(Integer, ForeignKey("clients.id"), nullable=True)
     client = relationship("Client", back_populates="users")
 

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from typing import List
 from .. import models, schemas, database
 from ..database import get_db
-from ..utils import get_current_user
+from ..utils import get_current_user, get_password_hash
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -35,3 +35,36 @@ def get_client_files(
         "end_date": file.end_date.strftime("%Y-%m-%d"),
         "uploaded_at": file.uploaded_at.strftime("%Y-%m-%d %H:%M:%S")
     } for file in files]
+
+
+@router.post("/affordplan/create-account", response_model=schemas.User)
+def create_entity_account(
+    entity_name: str,
+    email: str,
+    password: str,
+    role: str,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    """Create hospital or manufacturer account. Affordplan only."""
+    if current_user.role != "affordplan":
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    if role not in ["hospital", "manufacturer"]:
+        raise HTTPException(status_code=400, detail="Role must be 'hospital' or 'manufacturer'")
+
+    client = models.Client(name=entity_name)
+    db.add(client)
+    db.commit()
+    db.refresh(client)
+
+    user = models.User(
+        username=email,
+        password=get_password_hash(password),
+        role=role,
+        client_id=client.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -27,13 +27,20 @@ def seed_demo_users():
     db = SessionLocal()
     if db.query(Client).count() == 0:
         c1 = Client(name="AcmeCorp")
-        db.add(c1)
+        hospital = Client(name="CityHospital")
+        manufacturer = Client(name="MegaPharma")
+        db.add_all([c1, hospital, manufacturer])
         db.commit()
         db.refresh(c1)
+        db.refresh(hospital)
+        db.refresh(manufacturer)
         users = [
             User(username="admin", password=get_password_hash("admin123"), role="admin"),
             User(username="client1", password=get_password_hash("client123"), role="client", client_id=c1.id),
             User(username="employee1", password=get_password_hash("emp123"), role="employee", client_id=c1.id),
+            User(username="hospital@example.com", password=get_password_hash("hosp123"), role="hospital", client_id=hospital.id),
+            User(username="manufacturer@example.com", password=get_password_hash("manu123"), role="manufacturer", client_id=manufacturer.id),
+            User(username="affordplan@example.com", password=get_password_hash("afford123"), role="affordplan"),
         ]
         db.add_all(users)
         db.commit()


### PR DESCRIPTION
## Summary
- add manufacturer, hospital, and affordplan roles
- seed demo database with sample accounts for the new roles
- allow affordplan to create hospital/manufacturer accounts via new `/admin/affordplan/create-account` endpoint
- document additional roles in README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68523858b0148330a7f13c943e0fc99d